### PR TITLE
Fix Deprecation warning install.debian.yml

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install cron and openssl
   apt:
-    name: '{{ item }}'
-  with_items:
-    - openssl
-    - cron
+    name:
+      - openssl
+      - cron


### PR DESCRIPTION
 Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: 
['openssl', 'cron']` and remove the loop. This feature will be removed in version 2.11